### PR TITLE
feat: self attention block for stacked self attention

### DIFF
--- a/tests/networks/test_condencoder.py
+++ b/tests/networks/test_condencoder.py
@@ -23,7 +23,10 @@ layers_before_pool = [
     },
     (
         ("mlp", {"dims": (32, 32)}),
-        ("self_attention", {"num_heads": 4, "qkv_dim": 32, "transformer_block": True}),
+        (
+            "self_attention",
+            {"num_heads": [4, 8], "qkv_dim": [32, 64], "transformer_block": True},
+        ),
     ),
     (),
 ]


### PR DESCRIPTION
Added self-attention block with potentially multiple SA layers/transformer blocks, which is also now used by ConditionEncoder instead of old `SelfAttention`.
Backward compatibility (i.e. setting `num_heads`/`qkv_dim` to `int` rather than `Sequence`) should still be there.