### PR TITLE
SampledMetrics callback

### DIFF
--- a/src/cfp/training/__init__.py
+++ b/src/cfp/training/__init__.py
@@ -4,6 +4,7 @@ from cfp.training._callbacks import (
                                      ComputationCallback,
                                      LoggingCallback,
                                      Metrics,
+                                     SampledMetrics,
                                      PCADecodedMetrics,
                                      WandbLogger,
 )
@@ -19,4 +20,5 @@ __all__ = [
     "CallbackRunner",
     "PCADecodedMetrics",
     "PCADecoder",
+    "SampledMetrics",
 ]


### PR DESCRIPTION
`SampledMetrics` callback computes distributional metrics in large datasets using just `sample_size` observations. Follows same schema as `Metrics` callback.