### PR TITLE
fix dataset doc header

### DIFF
--- a/docs/user/datasets.rst
+++ b/docs/user/datasets.rst
@@ -1,5 +1,5 @@
-Model
-~~~~~
+Datasets
+~~~~~~~~
 .. module:: cellflow.datasets
 .. currentmodule:: cellflow
 .. autosummary::


### PR DESCRIPTION
"Model" appears twice in User API (https://cellflow.readthedocs.io/en/latest/user/index.html). This commit fixes this issue.