### PR TITLE
Feature and Speedup: predict batch

### DIFF
--- a/src/cellflow/solvers/_otfm.py
+++ b/src/cellflow/solvers/_otfm.py
@@ -199,6 +199,13 @@ class OTFlowMatching:
         -------
         The push-forward distribution of ``x`` under condition ``condition``.
         """
+        x_pred = self._predict_jit(x, condition, rng, **kwargs)
+        return np.array(x_pred)
+
+    def _predict_jit(
+        self, x: ArrayLike, condition: dict[str, ArrayLike], rng: jax.Array | None = None, **kwargs: Any
+    ) -> ArrayLike:
+        """See :meth:`OTFlowMatching.predict`."""
         kwargs.setdefault("dt0", None)
         kwargs.setdefault("solver", diffrax.Tsit5())
         kwargs.setdefault("stepsize_controller", diffrax.PIDController(rtol=1e-5, atol=1e-5))
@@ -226,7 +233,10 @@ class OTFlowMatching:
             return result.ys[0]
 
         x_pred = jax.jit(jax.vmap(solve_ode, in_axes=[0, None, None]))(x, condition, encoder_noise)
-        return np.array(x_pred)
+        return x_pred
+
+    def predict_batch(self, x: ArrayLike, condition: dict[str, ArrayLike], rng: jax.Array | None = None, **kwargs: Any) -> ArrayLike:
+        pass
 
     @property
     def is_trained(self) -> bool:


### PR DESCRIPTION
Hi, I wrote a batched predict function for otfm but I could do also in genot once it looks good.

For example this would change the code in `CellFlowTrainer._validation_step` to this instead of the jax.tree_map.
```
    def _validation_step(
        self,
        val_data: dict[str, ValidationSampler],
        mode: Literal["on_log_iteration", "on_train_end"] = "on_log_iteration",
    ) -> tuple[
        dict[str, dict[str, ArrayLike]],
        dict[str, dict[str, ArrayLike]],
    ]:
        """Compute predictions for validation data."""
        # TODO: Sample fixed number of conditions to validate on

        valid_pred_data: dict[str, dict[str, ArrayLike]] = {}
        valid_true_data: dict[str, dict[str, ArrayLike]] = {}
        for val_key, vdl in val_data.items():
            batch = vdl.sample(mode=mode)
            src = batch["source"]
            condition = batch.get("condition", None)
            true_tgt = batch["target"]

            valid_pred_data[val_key] = self.solver.predict_batch(src, condition)
            valid_true_data[val_key] = true_tgt
```
