### PR TITLE
try reducing the ubuntu image

### DIFF
--- a/.github/workflows/test-slow.yaml
+++ b/.github/workflows/test-slow.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python: "3.12"
           - os: macos-latest
             python: "3.12"


### PR DESCRIPTION
Fixes #257 

According to the discussion here:https://stackoverflow.com/questions/77182923/apparently-failed-github-actions-workflow-step-shows-a-hexagon-with-exclamation and inspired from the commit it mentions there
https://github.com/lightninglabs/taproot-assets/commit/beb76bc365e80a8d2bd872fae92f13cb34ef8d6e . I will first try a lower ubuntu version