### PR TITLE
Fix control splitting

### DIFF
--- a/src/cellflow/solvers/_otfm.py
+++ b/src/cellflow/solvers/_otfm.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from functools import partial
 from typing import Any
 
 import diffrax
@@ -263,6 +264,12 @@ class OTFlowMatching:
 
             pred_targets = batched_predict(src_inputs, batched_conditions)
             return {k: pred_targets[i] for i, k in enumerate(keys)}
+        elif isinstance(x, dict):
+            return jax.tree.map(
+                partial(self._predict_jit, rng=rng, **kwargs),
+                x,
+                condition,  # type: ignore[attr-defined]
+            )
         else:
             x_pred = self._predict_jit(x, condition, rng, **kwargs)
             return np.array(x_pred)

--- a/src/cellflow/training/_trainer.py
+++ b/src/cellflow/training/_trainer.py
@@ -68,7 +68,7 @@ class CellFlowTrainer:
             true_tgt = batch["target"]
             valid_source_data[val_key] = src
             valid_pred_data[val_key] = self.solver.predict(
-                src, condition=condition, batched=True, **self.predict_kwargs
+                src, condition=condition, **self.predict_kwargs
             )
             valid_true_data[val_key] = true_tgt
 

--- a/src/cellflow/training/_trainer.py
+++ b/src/cellflow/training/_trainer.py
@@ -67,9 +67,7 @@ class CellFlowTrainer:
             condition = batch.get("condition", None)
             true_tgt = batch["target"]
             valid_source_data[val_key] = src
-            valid_pred_data[val_key] = self.solver.predict(
-                src, condition=condition, **self.predict_kwargs
-            )
+            valid_pred_data[val_key] = self.solver.predict(src, condition=condition, **self.predict_kwargs)
             valid_true_data[val_key] = true_tgt
 
         return valid_source_data, valid_true_data, valid_pred_data


### PR DESCRIPTION
I noticed some problems with the handling of split covariates during prediction, which this PR is attempting to fix.

Issues:
* validation data belonging to more than one split covariate (and thus having multiple different source distributions) results in an error in predict, as the batched predict requires all source distributions to have the same shape
* prediction with more than one split covariate at a time does not work, as only the first control distribution is considered for all conditions

Proposed fixes:
* Set `batched=False` if more than one source distribution is in the validation data
* Get correct `control_to_perturbation` in `_dm.get_prediction_data()` so that control distributions are correctly matched to conditions