### PR TITLE
fix: correct dropout target and FC residual dim in SelfAttention transformer block

### DIFF
--- a/src/cellflow/networks/_utils.py
+++ b/src/cellflow/networks/_utils.py
@@ -277,8 +277,10 @@ class SelfAttention(BaseModule):
             if self.layer_norm:
                 z = nn.LayerNorm()(z)
             # FC layer with residual connection
-            z_ = self.act_fn(nn.Dense(self.qkv_dim)(z))
-            z_ = nn.Dropout(self.dropout_rate)(z, deterministic=not training)
+            # project back to the residual-stream dimension so the residual add is valid
+            # for any ``qkv_dim`` (the attention output keeps the input dimension)
+            z_ = self.act_fn(nn.Dense(z.shape[-1])(z))
+            z_ = nn.Dropout(self.dropout_rate)(z_, deterministic=not training)
             z = z + z_
 
         return z.squeeze(1) if squeeze else z
@@ -426,7 +428,6 @@ class SeedAttentionPooling(BaseModule):
         Q_ = jnp.concatenate(jnp.split(Q, self.num_heads, axis=2), axis=0)
         K_ = jnp.concatenate(jnp.split(K, self.num_heads, axis=2), axis=0)
         V_ = jnp.concatenate(jnp.split(V, self.num_heads, axis=2), axis=0)
-        A = jnp.matmul(Q_, K_.transpose(0, 2, 1)) / jnp.sqrt(self.v_dim)
         A = jnp.matmul(Q_, K_.transpose(0, 2, 1)) / jnp.sqrt(self.v_dim)
         if mask is not None:
             # mask from (batch_, 1 | num_heads, set_, set_) to (batch_ * num_heads, 1, set_)


### PR DESCRIPTION
## Summary

Fixes a bug in the `SelfAttention` transformer-block FC sublayer in `src/cellflow/networks/_utils.py`, plus a latent shape bug it was masking.

### 1. Dropout applied to the wrong variable
The FC sublayer applied dropout to `z` instead of `z_`, silently discarding the `Dense` output:
```python
z_ = self.act_fn(nn.Dense(self.qkv_dim)(z))
z_ = nn.Dropout(self.dropout_rate)(z, ...)   # bug: uses z, Dense output thrown away
z = z + z_
```
This degenerated the "FC layer with residual connection" into `z = z + dropout(z)` — no learned transformation ever applied.

### 2. Latent shape bug the original bug was hiding
Fixing the dropout target alone broke 72 tests with `add got incompatible shapes: (1,3,18) vs (1,3,32)`. The attention output keeps the **input** feature dimension (flax's `out_features` default), not `qkv_dim`, so the FC layer's `nn.Dense(self.qkv_dim)` made the residual `z + z_` fail whenever `qkv_dim != input_dim`. The original bug masked this by discarding the `Dense` output.

Fix: project the FC layer back to the residual-stream dimension (`nn.Dense(z.shape[-1])`), matching the correct pattern already used in `SeedAttentionPooling`.

### 3. Duplicate dead line
Removed a duplicated `A = jnp.matmul(Q_, K_.transpose(0, 2, 1)) / jnp.sqrt(self.v_dim)` in `SeedAttentionPooling` (the first was immediately overwritten).

## Behavior change note
⚠️ For models using `transformer_block=True`, the FC sublayer previously did nothing meaningful (`z = z + dropout(z)`); it now applies a real learned transformation. Output will differ from the old (broken) behavior — but there was nothing meaningful to preserve.

## Testing
All 506 tests in `tests/networks/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)