### PR TITLE
networks: layer registry + polymorphic dispatch

### DIFF
--- a/src/cellflow/networks/__init__.py
+++ b/src/cellflow/networks/__init__.py
@@ -2,6 +2,7 @@ from cellflow.networks._set_encoders import (
     ConditionEncoder,
 )
 from cellflow.networks._utils import (
+    LAYER_REGISTRY,
     FilmBlock,
     MLPBlock,
     ResNetBlock,
@@ -9,6 +10,7 @@ from cellflow.networks._utils import (
     SelfAttention,
     SelfAttentionBlock,
     TokenAttentionPooling,
+    register_layer,
 )
 from cellflow.networks._velocity_field import ConditionalVelocityField, GENOTConditionalVelocityField
 
@@ -24,4 +26,6 @@ __all__ = [
     "FilmBlock",
     "ResNetBlock",
     "SelfAttentionBlock",
+    "LAYER_REGISTRY",
+    "register_layer",
 ]

--- a/src/cellflow/networks/_utils.py
+++ b/src/cellflow/networks/_utils.py
@@ -617,8 +617,7 @@ def _get_layers(
                 layer_cls = LAYER_REGISTRY[layer_type]
             except KeyError:
                 raise ValueError(
-                    f"Unknown layer type: {layer_type!r}. "
-                    f"Registered layer types: {sorted(LAYER_REGISTRY)}."
+                    f"Unknown layer type: {layer_type!r}. Registered layer types: {sorted(LAYER_REGISTRY)}."
                 ) from None
             modules.append(layer_cls(**layer))
     if output_dim is not None:

--- a/src/cellflow/networks/_utils.py
+++ b/src/cellflow/networks/_utils.py
@@ -1,6 +1,7 @@
 import abc
 import math
 from collections.abc import Callable, Sequence
+from typing import ClassVar
 
 import jax
 import jax.numpy as jnp
@@ -18,6 +19,8 @@ __all__ = [
     "ResNetBlock",
     "SelfAttentionBlock",
     "sinusoidal_time_encoder",
+    "LAYER_REGISTRY",
+    "register_layer",
 ]
 
 
@@ -58,12 +61,52 @@ def sinusoidal_time_encoder(t: jnp.ndarray, time_freqs: int = 1024, time_max_per
 class BaseModule(abc.ABC, nn.Module):
     """Base module for condition encoder and its components."""
 
+    #: Whether this block's ``__call__`` accepts an attention mask as its second
+    #: positional argument. Declared as a :class:`~typing.ClassVar` so it stays a
+    #: pure class-level capability flag and is *not* turned into a ``flax`` module
+    #: field (which would alter the constructor signature). :func:`_apply_modules`
+    #: dispatches on this flag instead of hard-coding ``isinstance`` checks.
+    takes_attention_mask: ClassVar[bool] = False
+
     @abc.abstractmethod
     def __call__(self, x: jnp.ndarray, training: bool = True) -> jnp.ndarray:
         """Forward pass."""
         pass
 
 
+#: Registry mapping a ``layer_type`` string to the block class that implements it.
+#: Populated via the :func:`register_layer` decorator and consulted by
+#: :func:`_get_layers` to instantiate blocks from config dicts. New block types can
+#: be added by decorating them with ``@register_layer(...)`` without touching the
+#: dispatch code.
+LAYER_REGISTRY: dict[str, type[BaseModule]] = {}
+
+
+def register_layer(name: str) -> Callable[[type[BaseModule]], type[BaseModule]]:
+    """Register a network block class under ``name`` in :data:`LAYER_REGISTRY`.
+
+    The decorated class can then be referenced by ``name`` through the
+    ``"layer_type"`` key of a layer config and is instantiated by
+    :func:`_get_layers`.
+
+    Parameters
+    ----------
+    name
+        Key under which the decorated class is registered.
+
+    Returns
+    -------
+    A class decorator that registers the class and returns it unchanged.
+    """
+
+    def decorator(cls: type[BaseModule]) -> type[BaseModule]:
+        LAYER_REGISTRY[name] = cls
+        return cls
+
+    return decorator
+
+
+@register_layer("mlp")
 class MLPBlock(BaseModule):
     """
     MLP block.
@@ -290,6 +333,7 @@ class SelfAttention(BaseModule):
         return z.squeeze(1) if squeeze else z
 
 
+@register_layer("self_attention")
 class SelfAttentionBlock(BaseModule):
     """
     Several self-attention (+ optional FC layer) layers stacked together.
@@ -311,6 +355,10 @@ class SelfAttentionBlock(BaseModule):
     -------
     Output tensor of shape (batch_size, set_size, input_dim).
     """
+
+    #: This block consumes an attention mask (see :meth:`__call__`), so
+    #: :func:`_apply_modules` forwards ``attention_mask`` to it.
+    takes_attention_mask: ClassVar[bool] = True
 
     num_heads: Sequence[int] | int
     qkv_dim: Sequence[int] | int
@@ -565,13 +613,14 @@ def _get_layers(
         for layer in layers:
             layer = dict(layer)
             layer_type = layer.pop("layer_type", "mlp")
-            if layer_type == "mlp":
-                lay = MLPBlock(**layer)
-            elif layer_type == "self_attention":
-                lay = SelfAttentionBlock(**layer)
-            else:
-                raise ValueError(f"Unknown layer type: {layer_type}")
-            modules.append(lay)
+            try:
+                layer_cls = LAYER_REGISTRY[layer_type]
+            except KeyError:
+                raise ValueError(
+                    f"Unknown layer type: {layer_type!r}. "
+                    f"Registered layer types: {sorted(LAYER_REGISTRY)}."
+                ) from None
+            modules.append(layer_cls(**layer))
     if output_dim is not None:
         modules.append(nn.Dense(output_dim))
         if dropout_rate is not None:
@@ -587,7 +636,7 @@ def _apply_modules(
 ) -> jnp.ndarray:
     """Apply modules to conditions."""
     for module in modules:
-        if isinstance(module, SelfAttentionBlock):
+        if getattr(module, "takes_attention_mask", False):
             conditions = module(conditions, attention_mask, training)
         elif isinstance(module, nn.Dense):
             conditions = module(conditions)

--- a/tests/networks/test_layer_registry.py
+++ b/tests/networks/test_layer_registry.py
@@ -1,0 +1,147 @@
+from typing import ClassVar
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import linen as nn
+
+from cellflow.networks._utils import (
+    LAYER_REGISTRY,
+    BaseModule,
+    MLPBlock,
+    SelfAttentionBlock,
+    _apply_modules,
+    _get_layers,
+    register_layer,
+)
+
+
+class DummyBlock(BaseModule):
+    """A minimal custom block used to exercise the layer registry."""
+
+    width: int = 4
+
+    @nn.compact
+    def __call__(self, x: jnp.ndarray, training: bool = True) -> jnp.ndarray:
+        return nn.Dense(self.width)(x)
+
+
+class MaskEchoBlock(BaseModule):
+    """Custom block that consumes an attention mask.
+
+    It is *not* a :class:`SelfAttentionBlock`, so ``_apply_modules`` can only
+    forward the mask to it by honoring the ``takes_attention_mask`` capability
+    flag (rather than an ``isinstance`` check). The block adds the sum of the
+    received mask to its input so a test can assert exactly what was forwarded.
+    """
+
+    takes_attention_mask: ClassVar[bool] = True
+
+    @nn.compact
+    def __call__(
+        self,
+        x: jnp.ndarray,
+        mask: jnp.ndarray | None = None,
+        training: bool = True,
+    ) -> jnp.ndarray:
+        total = jnp.zeros(()) if mask is None else jnp.sum(mask)
+        return x + total
+
+
+@pytest.fixture
+def registered_blocks():
+    """Register the custom blocks and restore the registry afterwards."""
+    register_layer("dummy_block")(DummyBlock)
+    register_layer("mask_echo")(MaskEchoBlock)
+    try:
+        yield
+    finally:
+        LAYER_REGISTRY.pop("dummy_block", None)
+        LAYER_REGISTRY.pop("mask_echo", None)
+
+
+class TestLayerRegistry:
+    def test_builtin_blocks_registered(self):
+        # decorating the existing blocks keeps the default keys resolvable
+        assert LAYER_REGISTRY["mlp"] is MLPBlock
+        assert LAYER_REGISTRY["self_attention"] is SelfAttentionBlock
+
+    def test_register_and_build_custom_block(self, registered_blocks):
+        assert LAYER_REGISTRY["dummy_block"] is DummyBlock
+
+        modules = _get_layers([{"layer_type": "dummy_block", "width": 7}])
+
+        assert len(modules) == 1
+        assert isinstance(modules[0], DummyBlock)
+        assert modules[0].width == 7
+
+    def test_get_layers_resolves_builtins_and_default(self):
+        # a config without ``layer_type`` still defaults to "mlp"
+        modules = _get_layers(
+            [
+                {"dims": (8, 8)},
+                {"layer_type": "self_attention", "num_heads": 2, "qkv_dim": 8},
+            ]
+        )
+        assert isinstance(modules[0], MLPBlock)
+        assert isinstance(modules[1], SelfAttentionBlock)
+
+    def test_get_layers_appends_output_and_dropout(self):
+        modules = _get_layers([{"dims": (8, 8)}], output_dim=5, dropout_rate=0.1)
+        assert isinstance(modules[0], MLPBlock)
+        assert isinstance(modules[1], nn.Dense)
+        assert modules[1].features == 5
+        assert isinstance(modules[2], nn.Dropout)
+
+    def test_unknown_layer_type_lists_registered_keys(self):
+        with pytest.raises(ValueError, match="Unknown layer type") as exc_info:
+            _get_layers([{"layer_type": "does_not_exist"}])
+        msg = str(exc_info.value)
+        # the error should enumerate the registered keys to guide the user
+        assert "mlp" in msg
+        assert "self_attention" in msg
+
+    def test_capability_flags(self):
+        # the base default is False; only attention blocks flip it to True
+        assert MLPBlock.takes_attention_mask is False
+        assert SelfAttentionBlock.takes_attention_mask is True
+        assert MaskEchoBlock.takes_attention_mask is True
+
+    def test_apply_modules_forwards_mask_via_capability_flag(self, registered_blocks):
+        class Runner(nn.Module):
+            @nn.compact
+            def __call__(self, x, mask, training=True):
+                return _apply_modules([MaskEchoBlock()], x, mask, training)
+
+        rng = jax.random.PRNGKey(0)
+        x = jnp.zeros((2, 4))
+        mask = jnp.ones((2, 1, 3, 3))
+
+        runner = Runner()
+        variables = runner.init(rng, x, mask, training=False)
+        out = runner.apply(variables, x, mask, training=False)
+
+        # MaskEchoBlock adds sum(mask) to x, proving the mask reached a block
+        # that is dispatched purely via ``takes_attention_mask`` (it is not a
+        # SelfAttentionBlock).
+        assert jnp.allclose(out, jnp.sum(mask))
+
+    def test_apply_modules_non_mask_block_ignores_mask(self):
+        class Runner(nn.Module):
+            @nn.compact
+            def __call__(self, x, mask, training=True):
+                return _apply_modules([MLPBlock(dims=(4,))], x, mask, training)
+
+        rng = jax.random.PRNGKey(0)
+        x = jax.random.normal(rng, (2, 4))
+        mask_a = jnp.ones((2, 1, 3, 3))
+        mask_b = jnp.zeros((2, 1, 3, 3))
+
+        runner = Runner()
+        variables = runner.init(rng, x, mask_a, training=False)
+        out_a = runner.apply(variables, x, mask_a, training=False)
+        out_b = runner.apply(variables, x, mask_b, training=False)
+
+        # a block whose capability flag is False never receives the mask, so
+        # changing the mask must not change the output
+        assert jnp.allclose(out_a, out_b)


### PR DESCRIPTION
Adds a layer registry + polymorphic block dispatch so new network block types can be registered without editing core dispatch code in `src/cellflow/networks/_utils.py`.

After this we can have scaleflow add their layers like below
```python
@register_layer("scaleflow.adaln")                      # namespaced key
class AdaLNBlock(BaseModule):
    takes_attention_mask: ClassVar[bool] = True         # opt in to mask forwarding
    num_heads: int = 8
    @nn.compact
    def __call__(self, x, mask=None, training=True):
        ...
# any cellflow user / experiment config — no cellflow edits, no scaleflow re-export
CellFlow(...).prepare_model(
    condition_encoder_kwargs=dict(
        layers_after_pool=[{"layer_type": "scaleflow.adaln", "num_heads": 8}],
    )
)
```
