### PR TITLE
networks: export BaseModule from cellflow.networks

### DIFF
--- a/src/cellflow/networks/__init__.py
+++ b/src/cellflow/networks/__init__.py
@@ -2,6 +2,7 @@ from cellflow.networks._set_encoders import (
     ConditionEncoder,
 )
 from cellflow.networks._utils import (
+    BaseModule,
     FilmBlock,
     MLPBlock,
     ResNetBlock,
@@ -16,6 +17,7 @@ __all__ = [
     "ConditionalVelocityField",
     "GENOTConditionalVelocityField",
     "ConditionEncoder",
+    "BaseModule",
     "MLPBlock",
     "SelfAttention",
     "SeedAttentionPooling",


### PR DESCRIPTION
Export `BaseModule` from `cellflow.networks` so downstream packages can subclass it to define custom network blocks without reaching into the private `cellflow.networks._utils` module.