### PR TITLE
solvers: classifier-free guidance seam

### DIFF
--- a/src/cellflow/networks/__init__.py
+++ b/src/cellflow/networks/__init__.py
@@ -2,8 +2,8 @@ from cellflow.networks._set_encoders import (
     ConditionEncoder,
 )
 from cellflow.networks._utils import (
-    BaseModule,
     LAYER_REGISTRY,
+    BaseModule,
     FilmBlock,
     MLPBlock,
     ResNetBlock,

--- a/src/cellflow/networks/_velocity_field.py
+++ b/src/cellflow/networks/_velocity_field.py
@@ -52,6 +52,21 @@ class ConditionalVelocityField(nn.Module):
             Layers after pooling.
         cond_output_dropout
             Dropout rate for the last layer of the condition encoder.
+        condition_dropout_prob
+            Probability of dropping the whole condition during training so that the
+            network also learns an unconditional velocity field. This enables
+            classifier-free guidance at inference time via the ``force_uncond``
+            argument of :meth:`__call__`. A value of ``0.0`` (the default) disables
+            condition dropout and reproduces the standard conditional behavior.
+        condition_null
+            How the condition is nulled when it is dropped (both during training via
+            ``condition_dropout_prob`` and at inference via ``force_uncond``):
+
+            - ``'zero_embedding'``: zero the condition embedding after the encoder
+              (the default).
+            - ``'mask_value'``: fill the raw condition inputs with :attr:`mask_value`
+              and route the resulting fully-masked set through the encoder.
+
         condition_encoder_kwargs
             Keyword arguments for the condition encoder.
         act_fn
@@ -105,6 +120,8 @@ class ConditionalVelocityField(nn.Module):
     layers_before_pool: Layers_separate_input_t | Layers_t = dc_field(default_factory=lambda: [])
     layers_after_pool: Layers_t = dc_field(default_factory=lambda: [])
     cond_output_dropout: float = 0.0
+    condition_dropout_prob: float = 0.0
+    condition_null: Literal["zero_embedding", "mask_value"] = "zero_embedding"
     mask_value: float = 0.0
     condition_encoder_kwargs: dict[str, Any] = dc_field(default_factory=lambda: {})
     act_fn: Callable[[jnp.ndarray], jnp.ndarray] = nn.silu
@@ -192,8 +209,11 @@ class ConditionalVelocityField(nn.Module):
         cond: dict[str, jnp.ndarray],
         encoder_noise: jnp.ndarray,
         train: bool = True,
+        force_uncond: bool = False,
     ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
         squeeze = x_t.ndim == 1
+        if self.condition_null == "mask_value":
+            cond = self._maybe_null_input(cond, train=train, force_uncond=force_uncond)
         cond_mean, cond_logvar = self.condition_encoder(cond, training=train)
         if self.condition_mode == "deterministic":
             cond_embedding = cond_mean
@@ -201,6 +221,8 @@ class ConditionalVelocityField(nn.Module):
             cond_embedding = cond_mean + encoder_noise * jnp.exp(cond_logvar / 2.0)
 
         cond_embedding = self.layer_cond_output_dropout(cond_embedding, deterministic=not train)
+        if self.condition_null == "zero_embedding":
+            cond_embedding = self._maybe_null_embedding(cond_embedding, train=train, force_uncond=force_uncond)
 
         t_encoded = sinusoidal_time_encoder(t, time_freqs=self.time_freqs, time_max_period=self.time_max_period)
         t_encoded = self.time_encoder(t_encoded, training=train)
@@ -226,6 +248,60 @@ class ConditionalVelocityField(nn.Module):
 
         out = self.decoder(out, training=train)
         return self.output_layer(out), cond_mean, cond_logvar
+
+    def _maybe_null_embedding(
+        self,
+        cond_embedding: jnp.ndarray,
+        train: bool,
+        force_uncond: bool,
+    ) -> jnp.ndarray:
+        """Null the condition embedding for classifier-free guidance (``condition_null='zero_embedding'``).
+
+        - If ``force_uncond`` is set, the condition is always dropped, yielding the
+          unconditional velocity field (used at inference time).
+        - Otherwise, during training the whole condition is dropped independently per
+          set element with probability :attr:`condition_dropout_prob`.
+
+        With ``force_uncond=False`` and ``condition_dropout_prob == 0.0`` (the
+        defaults) this is a no-op that reproduces the standard conditional behavior
+        byte-for-byte: no random number is drawn and the embedding is returned as-is.
+        """
+        if force_uncond:
+            return jnp.zeros_like(cond_embedding)
+        if train and self.condition_dropout_prob > 0.0:
+            drop_rng = self.make_rng("dropout")
+            keep = jax.random.bernoulli(
+                drop_rng,
+                p=1.0 - self.condition_dropout_prob,
+                shape=(cond_embedding.shape[0], 1),
+            )
+            return jnp.where(keep, cond_embedding, jnp.zeros_like(cond_embedding))
+        return cond_embedding
+
+    def _maybe_null_input(
+        self,
+        cond: dict[str, jnp.ndarray],
+        train: bool,
+        force_uncond: bool,
+    ) -> dict[str, jnp.ndarray]:
+        """Null the raw condition by filling it with :attr:`mask_value` (``condition_null='mask_value'``).
+
+        This routes an all-masked condition set through the condition encoder, so the
+        unconditional representation is whatever the encoder maps a fully-masked set
+        to (matching :mod:`cellflow`'s handling of padded conditions). It mirrors the
+        drop policy of :meth:`_maybe_null_embedding`: always dropped when
+        ``force_uncond`` is set, otherwise dropped per set element with probability
+        :attr:`condition_dropout_prob` during training. With the defaults it returns
+        ``cond`` unchanged and draws no random number.
+        """
+        if force_uncond:
+            return jax.tree_util.tree_map(lambda c: jnp.full_like(c, self.mask_value), cond)
+        if train and self.condition_dropout_prob > 0.0:
+            drop_rng = self.make_rng("dropout")
+            n = next(iter(cond.values())).shape[0]
+            keep = jax.random.bernoulli(drop_rng, p=1.0 - self.condition_dropout_prob, shape=(n, 1, 1))
+            return jax.tree_util.tree_map(lambda c: jnp.where(keep, c, jnp.full_like(c, self.mask_value)), cond)
+        return cond
 
     def get_condition_embedding(self, condition: dict[str, jnp.ndarray]) -> tuple[jnp.ndarray, jnp.ndarray]:
         """Get the embedding of the condition.

--- a/src/cellflow/solvers/__init__.py
+++ b/src/cellflow/solvers/__init__.py
@@ -1,4 +1,4 @@
 from cellflow.solvers._genot import GENOT
-from cellflow.solvers._otfm import OTFlowMatching
+from cellflow.solvers._otfm import ClassifierFreeGuidance, Guidance, OTFlowMatching
 
-__all__ = ["GENOT", "OTFlowMatching"]
+__all__ = ["GENOT", "OTFlowMatching", "ClassifierFreeGuidance", "Guidance"]

--- a/src/cellflow/solvers/_otfm.py
+++ b/src/cellflow/solvers/_otfm.py
@@ -1,6 +1,6 @@
 import warnings
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 import diffrax
 import jax
@@ -16,7 +16,88 @@ from cellflow._types import ArrayLike
 from cellflow.networks._velocity_field import ConditionalVelocityField
 from cellflow.solvers.utils import ema_update
 
-__all__ = ["OTFlowMatching"]
+__all__ = ["OTFlowMatching", "ClassifierFreeGuidance", "Guidance"]
+
+# A velocity closure with the diffrax signature ``(t, x, args) -> velocity``,
+# where ``args`` is ``(params, condition, encoder_noise)``.
+VelocityFn = Callable[[jnp.ndarray, jnp.ndarray, tuple[Any, ...]], jnp.ndarray]
+
+
+@runtime_checkable
+class Guidance(Protocol):
+    """Pluggable transform applied to the base velocity field on the predict path.
+
+    A guidance strategy receives the base (conditional) velocity closure and the
+    inference train state, and returns a new velocity closure with the same
+    ``(t, x, args) -> velocity`` signature.
+    """
+
+    def wrap(self, vf: VelocityFn, inference_state: train_state.TrainState) -> VelocityFn:
+        """Wrap the base velocity ``vf`` and return the guided velocity."""
+        ...
+
+
+class ClassifierFreeGuidance:
+    """Classifier-free guidance on the predict path.
+
+    Combines the conditional velocity ``v_cond`` with the unconditional velocity
+    ``v_null`` (obtained by forcing the velocity field to drop its condition via
+    ``force_uncond=True``) according to ``v = v_null + scale * (v_cond - v_null)``.
+
+    A ``scale`` of ``1.0`` recovers the purely conditional velocity (and thus the
+    behavior without guidance), while larger values amplify the influence of the
+    condition. Using this strategy only makes sense for a velocity field trained
+    with ``condition_dropout_prob > 0`` so that ``v_null`` is meaningful.
+
+    How the unconditional ``v_null`` is defined (zeroed embedding vs a
+    :attr:`~cellflow.networks.ConditionalVelocityField.mask_value`-filled condition)
+    is controlled by the velocity field's ``condition_null`` mode; this strategy is
+    agnostic to it.
+
+    The equivalent "guidance weight" convention ``(1 + w) * v_cond - w * v_null``
+    (with ``w = 0`` meaning no guidance) is available via :meth:`from_ode_weight`,
+    since ``scale = 1 + w``.
+
+    Parameters
+    ----------
+    scale
+        Guidance strength.
+    """
+
+    def __init__(self, scale: float):
+        self.scale = scale
+
+    @classmethod
+    def from_ode_weight(cls, cfg_ode_weight: float) -> "ClassifierFreeGuidance":
+        """Build from the ``cfg_ode_weight`` convention: ``(1 + w) * v_cond - w * v_null``.
+
+        This is the parameterization used elsewhere in the ecosystem, where
+        ``cfg_ode_weight = 0`` means no guidance and larger values increase it. It
+        maps to ``scale = 1 + cfg_ode_weight``.
+        """
+        if cfg_ode_weight < 0:
+            raise ValueError("cfg_ode_weight must be non-negative.")
+        return cls(scale=1.0 + cfg_ode_weight)
+
+    def wrap(self, vf: VelocityFn, inference_state: train_state.TrainState) -> VelocityFn:
+        """Return a velocity closure computing ``v_null + scale * (v_cond - v_null)``."""
+        scale = self.scale
+
+        def guided_vf(t: jnp.ndarray, x: jnp.ndarray, args: tuple[Any, ...]) -> jnp.ndarray:
+            params, condition, encoder_noise = args
+            v_cond = vf(t, x, args)
+            v_null = inference_state.apply_fn(
+                {"params": params},
+                t,
+                x,
+                condition,
+                encoder_noise,
+                train=False,
+                force_uncond=True,
+            )[0]
+            return v_null + scale * (v_cond - v_null)
+
+        return guided_vf
 
 
 class OTFlowMatching:
@@ -40,6 +121,11 @@ class OTFlowMatching:
         time_sampler
             Time sampler with a ``(rng, n_samples) -> time`` signature, see e.g.
             :func:`ott.solvers.utils.uniform_sampler`.
+        guidance
+            Optional guidance strategy applied to the velocity field on the predict
+            path, see e.g. :class:`ClassifierFreeGuidance`. If :obj:`None` (the
+            default), the plain conditional velocity field is used and prediction is
+            unchanged.
         kwargs
             Keyword arguments for :meth:`cellflow.networks.ConditionalVelocityField.create_train_state`.
     """
@@ -50,6 +136,7 @@ class OTFlowMatching:
         probability_path: BaseFlow,
         match_fn: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray] | None = None,
         time_sampler: Callable[[jax.Array, int], jnp.ndarray] = solver_utils.uniform_sampler,
+        guidance: Guidance | None = None,
         **kwargs: Any,
     ):
         self._is_trained: bool = False
@@ -59,6 +146,7 @@ class OTFlowMatching:
         self.probability_path = probability_path
         self.time_sampler = time_sampler
         self.match_fn = jax.jit(match_fn)
+        self.guidance = guidance
         self.ema = kwargs.pop("ema", 1.0)
 
         self.vf_state = self.vf.create_train_state(input_dim=self.vf.output_dims[-1], **kwargs)
@@ -187,8 +275,27 @@ class OTFlowMatching:
             return np.asarray(cond_mean), np.asarray(cond_logvar)
         return cond_mean, cond_logvar
 
+    def _base_velocity(self) -> VelocityFn:
+        """Return the base (conditional) velocity closure used on the predict path.
+
+        The closure has the diffrax ``(t, x, args) -> velocity`` signature, with
+        ``args`` being ``(params, condition, encoder_noise)``, and evaluates the
+        inference velocity field conditionally (``force_uncond=False``).
+        """
+
+        def vf(t: jnp.ndarray, x: jnp.ndarray, args: tuple[Any, dict[str, jnp.ndarray], jnp.ndarray]) -> jnp.ndarray:
+            params, condition, encoder_noise = args
+            return self.vf_state_inference.apply_fn({"params": params}, t, x, condition, encoder_noise, train=False)[0]
+
+        return vf
+
     def _get_predict_fn(self, kwargs_frozen: frozen_dict.FrozenDict) -> Callable:
         """Build and cache a jit+vmap predict function for the given diffrax kwargs.
+
+        The base velocity closure is produced by :meth:`_base_velocity` and, when a
+        guidance strategy is set via ``guidance``, wrapped by it. With
+        ``guidance=None`` the closure is exactly the base conditional velocity, so
+        prediction is unchanged (no unconditional velocity is computed).
 
         The returned function is created once per unique set of diffrax kwargs,
         then reused on subsequent calls.
@@ -198,9 +305,9 @@ class OTFlowMatching:
 
         kwargs = dict(kwargs_frozen)
 
-        def vf(t: jnp.ndarray, x: jnp.ndarray, args: tuple[Any, dict[str, jnp.ndarray], jnp.ndarray]) -> jnp.ndarray:
-            params, condition, encoder_noise = args
-            return self.vf_state_inference.apply_fn({"params": params}, t, x, condition, encoder_noise, train=False)[0]
+        vf = self._base_velocity()
+        if self.guidance is not None:
+            vf = self.guidance.wrap(vf, self.vf_state_inference)
 
         def solve_ode(
             params: Any, x: jnp.ndarray, condition: dict[str, jnp.ndarray], encoder_noise: jnp.ndarray

--- a/tests/solver/test_solver.py
+++ b/tests/solver/test_solver.py
@@ -1,6 +1,8 @@
 import warnings
 
+import diffrax
 import jax
+import jax.numpy as jnp
 import numpy as np
 import optax
 import pytest
@@ -8,6 +10,7 @@ import pytest
 import cellflow
 from cellflow._compat import ConstantNoiseFlow
 from cellflow.solvers import _genot, _otfm
+from cellflow.solvers._otfm import ClassifierFreeGuidance
 from cellflow.utils import match_linear
 
 src = {
@@ -177,3 +180,279 @@ class TestSolver:
                     solver1.vf_state.params,
                 )
             )
+
+
+def _make_otfm(condition_dropout_prob=0.0, guidance=None, condition_null="zero_embedding"):
+    """Build a small OTFlowMatching solver for guidance tests."""
+    vf = cellflow.networks.ConditionalVelocityField(
+        output_dim=5,
+        max_combination_length=2,
+        condition_embedding_dim=12,
+        hidden_dims=(32, 32),
+        decoder_dims=(32, 32),
+        condition_dropout_prob=condition_dropout_prob,
+        condition_null=condition_null,
+    )
+    return _otfm.OTFlowMatching(
+        vf=vf,
+        match_fn=match_linear,
+        probability_path=ConstantNoiseFlow(0.0),
+        optimizer=optax.adam(1e-3),
+        conditions={"drug": np.random.rand(2, 1, 3)},
+        rng=vf_rng,
+        guidance=guidance,
+    )
+
+
+class TestGuidance:
+    def test_predict_guidance_none_matches_conditional_solve(self):
+        """With ``guidance=None`` predict reproduces the pre-change conditional-only solve.
+
+        The base velocity closure is reconstructed exactly as it existed before the
+        guidance seam and integrated with the same diffrax defaults; the result must
+        match ``solver.predict`` bit-for-bit (no unconditional velocity is computed).
+        """
+        solver = _make_otfm(guidance=None)
+        assert solver.guidance is None
+
+        x = jnp.ones((4, 5))
+        condition = {"drug": jnp.ones((1, 2, 3))}
+
+        pred = solver.predict(x, condition)
+
+        # Manually rebuild the conditional-only predict path (pre-change behavior).
+        kwargs = {
+            "dt0": None,
+            "solver": diffrax.Tsit5(),
+            "stepsize_controller": diffrax.PIDController(rtol=1e-5, atol=1e-5),
+        }
+        encoder_noise = jnp.zeros((1, solver.vf.condition_embedding_dim))
+        params = solver.vf_state_inference.params
+
+        def vf(t, y, args):
+            p, cond_, enc = args
+            return solver.vf_state_inference.apply_fn({"params": p}, t, y, cond_, enc, train=False)[0]
+
+        def solve_ode(p, y, cond_, enc):
+            term = diffrax.ODETerm(vf)
+            result = diffrax.diffeqsolve(term, t0=0.0, t1=1.0, y0=y, args=(p, cond_, enc), **kwargs)
+            return result.ys[0]
+
+        manual = jax.jit(jax.vmap(solve_ode, in_axes=[None, 0, None, None]))(params, x, condition, encoder_noise)
+
+        assert np.allclose(pred, np.asarray(manual), atol=1e-6, rtol=1e-6)
+
+    def test_classifier_free_guidance_wraps_velocity(self):
+        """The wrapped velocity equals ``v_null + scale * (v_cond - v_null)``."""
+        w = 3.0
+        solver = _make_otfm(condition_dropout_prob=0.5, guidance=ClassifierFreeGuidance(w))
+        assert isinstance(solver.guidance, ClassifierFreeGuidance)
+
+        t = jnp.array(0.3)
+        x = jnp.ones((5,))
+        condition = {"drug": jnp.ones((1, 2, 3))}
+        params = solver.vf_state_inference.params
+        encoder_noise = jnp.zeros((1, solver.vf.condition_embedding_dim))
+        args = (params, condition, encoder_noise)
+
+        base_vf = solver._base_velocity()
+        v_cond = base_vf(t, x, args)
+        v_null = solver.vf_state_inference.apply_fn(
+            {"params": params}, t, x, condition, encoder_noise, train=False, force_uncond=True
+        )[0]
+
+        guided_vf = solver.guidance.wrap(base_vf, solver.vf_state_inference)
+        v_guided = guided_vf(t, x, args)
+
+        expected = v_null + w * (v_cond - v_null)
+        assert np.allclose(np.asarray(v_guided), np.asarray(expected), atol=1e-6)
+        # The unconditional velocity must actually differ, otherwise the test is vacuous.
+        assert not np.allclose(np.asarray(v_null), np.asarray(v_cond), atol=1e-5)
+
+    def test_classifier_free_guidance_scale_one_is_conditional(self):
+        """At ``scale=1.0`` the guided velocity reduces to the conditional velocity."""
+        solver = _make_otfm(condition_dropout_prob=0.5, guidance=ClassifierFreeGuidance(1.0))
+
+        t = jnp.array(0.7)
+        x = jnp.ones((5,))
+        condition = {"drug": jnp.ones((1, 2, 3))}
+        params = solver.vf_state_inference.params
+        encoder_noise = jnp.zeros((1, solver.vf.condition_embedding_dim))
+        args = (params, condition, encoder_noise)
+
+        base_vf = solver._base_velocity()
+        v_cond = base_vf(t, x, args)
+        v_guided = solver.guidance.wrap(base_vf, solver.vf_state_inference)(t, x, args)
+
+        assert np.allclose(np.asarray(v_guided), np.asarray(v_cond), atol=1e-6)
+
+    def test_condition_dropout_training_runs(self, dataloader):
+        """Training with ``condition_dropout_prob>0`` exercises the drop path and stays finite."""
+        solver = _make_otfm(condition_dropout_prob=0.5)
+        trainer = cellflow.training.CellFlowTrainer(
+            solver=solver, predict_kwargs={"max_steps": 3, "throw": False}
+        )
+        trainer.train(dataloader=dataloader, num_iterations=2, valid_freq=10)
+
+        pred = solver.predict(jnp.ones((4, 5)), {"drug": jnp.ones((1, 2, 3))})
+        assert pred.shape == (4, 5)
+        assert np.all(np.isfinite(pred))
+
+    def test_from_ode_weight_parameterization(self):
+        """``from_ode_weight(w)`` maps to ``scale = 1 + w`` and rejects negative weights."""
+        assert ClassifierFreeGuidance.from_ode_weight(0.0).scale == 1.0
+        assert ClassifierFreeGuidance.from_ode_weight(2.0).scale == 3.0
+        with pytest.raises(ValueError, match="cfg_ode_weight must be non-negative"):
+            ClassifierFreeGuidance.from_ode_weight(-1.0)
+
+    @pytest.mark.parametrize("pooling", ["mean", "attention_token", "attention_seed"])
+    def test_mask_value_null_matches_mask_filled_condition(self, pooling):
+        """With ``condition_null='mask_value'``, ``force_uncond`` equals evaluating the vf on a mask-filled condition."""
+        vf = cellflow.networks.ConditionalVelocityField(
+            output_dim=5,
+            max_combination_length=2,
+            condition_embedding_dim=12,
+            hidden_dims=(32, 32),
+            decoder_dims=(32, 32),
+            condition_dropout_prob=0.5,
+            condition_null="mask_value",
+            pooling=pooling,
+        )
+        solver = _otfm.OTFlowMatching(
+            vf=vf,
+            match_fn=match_linear,
+            probability_path=ConstantNoiseFlow(0.0),
+            optimizer=optax.adam(1e-3),
+            conditions={"drug": np.random.rand(2, 1, 3)},
+            rng=vf_rng,
+        )
+
+        t = jnp.array(0.3)
+        x = jnp.ones((5,))
+        condition = {"drug": jnp.ones((1, 2, 3))}
+        params = solver.vf_state_inference.params
+        encoder_noise = jnp.zeros((1, solver.vf.condition_embedding_dim))
+
+        v_null_force = solver.vf_state_inference.apply_fn(
+            {"params": params}, t, x, condition, encoder_noise, train=False, force_uncond=True
+        )[0]
+        # Reference null: the raw condition filled with mask_value, run through the vf.
+        null_cond = {k: jnp.full_like(v, solver.vf.mask_value) for k, v in condition.items()}
+        v_null_ref = solver.vf_state_inference.apply_fn(
+            {"params": params}, t, x, null_cond, encoder_noise, train=False
+        )[0]
+
+        assert np.all(np.isfinite(np.asarray(v_null_force)))
+        assert np.allclose(np.asarray(v_null_force), np.asarray(v_null_ref), atol=1e-6)
+
+    def test_mask_value_null_differs_from_zero_embedding(self):
+        """The two null conventions produce different unconditional velocities."""
+        t = jnp.array(0.3)
+        x = jnp.ones((5,))
+        condition = {"drug": jnp.ones((1, 2, 3))}
+
+        def v_null(condition_null):
+            solver = _make_otfm(condition_dropout_prob=0.5, condition_null=condition_null)
+            params = solver.vf_state_inference.params
+            encoder_noise = jnp.zeros((1, solver.vf.condition_embedding_dim))
+            return solver.vf_state_inference.apply_fn(
+                {"params": params}, t, x, condition, encoder_noise, train=False, force_uncond=True
+            )[0]
+
+        assert not np.allclose(np.asarray(v_null("zero_embedding")), np.asarray(v_null("mask_value")), atol=1e-5)
+
+    def test_theislab_parity_guidance_formula(self):
+        """mask_value null + from_ode_weight reproduces theislab's ``(1+w)*v_cond - w*v_null``."""
+        w = 2.0
+        solver = _make_otfm(
+            condition_dropout_prob=0.5,
+            condition_null="mask_value",
+            guidance=ClassifierFreeGuidance.from_ode_weight(w),
+        )
+
+        t = jnp.array(0.4)
+        x = jnp.ones((5,))
+        condition = {"drug": jnp.ones((1, 2, 3))}
+        params = solver.vf_state_inference.params
+        encoder_noise = jnp.zeros((1, solver.vf.condition_embedding_dim))
+        args = (params, condition, encoder_noise)
+
+        base_vf = solver._base_velocity()
+        v_cond = base_vf(t, x, args)
+        v_null = solver.vf_state_inference.apply_fn(
+            {"params": params}, t, x, condition, encoder_noise, train=False, force_uncond=True
+        )[0]
+
+        v_guided = solver.guidance.wrap(base_vf, solver.vf_state_inference)(t, x, args)
+        expected = (1.0 + w) * v_cond - w * v_null
+        assert np.allclose(np.asarray(v_guided), np.asarray(expected), atol=1e-6)
+
+    def test_mask_value_training_runs(self, dataloader):
+        """Training with ``condition_null='mask_value'`` and dropout>0 stays finite."""
+        solver = _make_otfm(condition_dropout_prob=0.5, condition_null="mask_value")
+        trainer = cellflow.training.CellFlowTrainer(
+            solver=solver, predict_kwargs={"max_steps": 3, "throw": False}
+        )
+        trainer.train(dataloader=dataloader, num_iterations=2, valid_freq=10)
+
+        pred = solver.predict(jnp.ones((4, 5)), {"drug": jnp.ones((1, 2, 3))})
+        assert pred.shape == (4, 5)
+        assert np.all(np.isfinite(pred))
+
+    @pytest.mark.parametrize("condition_null", ["zero_embedding", "mask_value"])
+    def test_predict_with_guidance_end_to_end(self, condition_null):
+        """The full jit+vmap+diffrax predict path applies guidance (array and dict inputs)."""
+        scale = 3.0
+        solver = _make_otfm(
+            condition_dropout_prob=0.5, condition_null=condition_null, guidance=ClassifierFreeGuidance(scale)
+        )
+        x = jnp.ones((6, 5))
+        condition = {"drug": jnp.ones((1, 2, 3))}
+
+        pred = solver.predict(x, condition)
+        assert pred.shape == (6, 5)
+        assert np.all(np.isfinite(pred))
+
+        # Dict / batched input path.
+        pred_batched = solver.predict({("a",): np.asarray(x)}, {("a",): {"drug": np.asarray(condition["drug"])}})
+        assert pred_batched[("a",)].shape == (6, 5)
+        assert np.all(np.isfinite(pred_batched[("a",)]))
+
+        # The jitted predict must actually apply guidance: match a manual guided ODE solve.
+        kwargs = {
+            "dt0": None,
+            "solver": diffrax.Tsit5(),
+            "stepsize_controller": diffrax.PIDController(rtol=1e-5, atol=1e-5),
+        }
+        params = solver.vf_state_inference.params
+        encoder_noise = jnp.zeros((1, solver.vf.condition_embedding_dim))
+
+        def guided(t, y, args):
+            p, c, e = args
+            v_cond = solver.vf_state_inference.apply_fn({"params": p}, t, y, c, e, train=False)[0]
+            v_null = solver.vf_state_inference.apply_fn({"params": p}, t, y, c, e, train=False, force_uncond=True)[0]
+            return v_null + scale * (v_cond - v_null)
+
+        def solve_ode(p, y, c, e):
+            return diffrax.diffeqsolve(diffrax.ODETerm(guided), t0=0.0, t1=1.0, y0=y, args=(p, c, e), **kwargs).ys[0]
+
+        manual = jax.jit(jax.vmap(solve_ode, in_axes=[None, 0, None, None]))(params, x, condition, encoder_noise)
+        assert np.allclose(pred, np.asarray(manual), atol=1e-5)
+
+    def test_predict_guidance_transparent_and_effective_end_to_end(self):
+        """End-to-end: ``scale=1`` reproduces no-guidance; stronger guidance changes the prediction."""
+        x = jnp.ones((6, 5))
+        condition = {"drug": jnp.ones((1, 2, 3))}
+
+        pred_none = _make_otfm(condition_dropout_prob=0.5, condition_null="mask_value").predict(x, condition)
+        pred_one = _make_otfm(
+            condition_dropout_prob=0.5, condition_null="mask_value", guidance=ClassifierFreeGuidance(1.0)
+        ).predict(x, condition)
+        pred_strong = _make_otfm(
+            condition_dropout_prob=0.5, condition_null="mask_value", guidance=ClassifierFreeGuidance(5.0)
+        ).predict(x, condition)
+
+        # scale=1 reduces to the conditional velocity -> identical to no guidance (shared init params).
+        assert np.allclose(pred_none, pred_one, atol=1e-4)
+        # Stronger guidance actually changes the prediction.
+        assert not np.allclose(pred_none, pred_strong, atol=1e-3)

--- a/tests/solver/test_solver.py
+++ b/tests/solver/test_solver.py
@@ -289,9 +289,7 @@ class TestGuidance:
     def test_condition_dropout_training_runs(self, dataloader):
         """Training with ``condition_dropout_prob>0`` exercises the drop path and stays finite."""
         solver = _make_otfm(condition_dropout_prob=0.5)
-        trainer = cellflow.training.CellFlowTrainer(
-            solver=solver, predict_kwargs={"max_steps": 3, "throw": False}
-        )
+        trainer = cellflow.training.CellFlowTrainer(solver=solver, predict_kwargs={"max_steps": 3, "throw": False})
         trainer.train(dataloader=dataloader, num_iterations=2, valid_freq=10)
 
         pred = solver.predict(jnp.ones((4, 5)), {"drug": jnp.ones((1, 2, 3))})
@@ -390,9 +388,7 @@ class TestGuidance:
     def test_mask_value_training_runs(self, dataloader):
         """Training with ``condition_null='mask_value'`` and dropout>0 stays finite."""
         solver = _make_otfm(condition_dropout_prob=0.5, condition_null="mask_value")
-        trainer = cellflow.training.CellFlowTrainer(
-            solver=solver, predict_kwargs={"max_steps": 3, "throw": False}
-        )
+        trainer = cellflow.training.CellFlowTrainer(solver=solver, predict_kwargs={"max_steps": 3, "throw": False})
         trainer.train(dataloader=dataloader, num_iterations=2, valid_freq=10)
 
         pred = solver.predict(jnp.ones((4, 5)), {"drug": jnp.ones((1, 2, 3))})


### PR DESCRIPTION
Add velocity-field primitives for classifier-free guidance and a pluggable guidance transform on the OTFlowMatching predict path.

- ConditionalVelocityField: new condition_dropout_prob field (train-time whole-condition dropout to learn an unconditional field) and a force_uncond flag on __call__ to return the unconditional velocity. A condition_null mode selects how the condition is nulled: 'zero_embedding' (default) zeros the post-encoder embedding; 'mask_value' fills the raw condition with mask_value and routes the fully-masked set through the encoder. Defaults reproduce the previous behavior.
- OTFlowMatching: factor the base velocity closure into _base_velocity, add a guidance=None constructor arg, and wrap the closure with guidance when set. With guidance=None the predict path is unchanged (no v_null computed).
- ClassifierFreeGuidance(scale): v_null + scale*(v_cond - v_null), with v_null via force_uncond=True. ClassifierFreeGuidance.from_ode_weight(w) provides the (1+w)*v_cond - w*v_null convention (scale = 1 + w).