### PR TITLE
solvers: name-based solver/VF registry

### DIFF
--- a/src/cellflow/model/_cellflow.py
+++ b/src/cellflow/model/_cellflow.py
@@ -23,7 +23,7 @@ from cellflow.data._datamanager import DataManager
 from cellflow.model._utils import _write_predictions
 from cellflow.networks import _velocity_field
 from cellflow.plotting import _utils
-from cellflow.solvers import _genot, _otfm
+from cellflow.solvers import SOLVER_REGISTRY, _genot, _otfm
 from cellflow.training._callbacks import BaseCallback
 from cellflow.training._trainer import CellFlowTrainer
 from cellflow.utils import match_linear
@@ -43,17 +43,16 @@ class CellFlow:
         adata
             An :class:`~anndata.AnnData` object to extract the training data from.
         solver
-            Solver to use for training. Either ``'otfm'`` or ``'genot'``.
+            Solver to use for training. Any name registered in
+            :data:`cellflow.solvers.SOLVER_REGISTRY` (``'otfm'`` or ``'genot'`` by default, extendable
+            via :func:`cellflow.solvers.register_solver`).
     """
 
-    def __init__(self, adata: ad.AnnData, solver: Literal["otfm", "genot"] = "otfm"):
+    def __init__(self, adata: ad.AnnData, solver: str = "otfm"):
         self._adata = adata
-        self._solver_class = _otfm.OTFlowMatching if solver == "otfm" else _genot.GENOT
-        self._vf_class = (
-            _velocity_field.ConditionalVelocityField
-            if solver == "otfm"
-            else _velocity_field.GENOTConditionalVelocityField
-        )
+        if solver not in SOLVER_REGISTRY:
+            raise ValueError(f"Unknown solver {solver!r}. Registered solvers: {sorted(SOLVER_REGISTRY)}.")
+        self._solver_class, self._vf_class = SOLVER_REGISTRY[solver]
         self._dataloader: TrainSampler | OOCTrainSampler | None = None
         self._trainer: CellFlowTrainer | None = None
         self._validation_data: dict[str, ValidationData] = {"predict_kwargs": {}}
@@ -429,17 +428,8 @@ class CellFlow:
                 raise ValueError("Stochastic condition embeddings require `regularization`>0.")
 
         condition_encoder_kwargs = condition_encoder_kwargs or {}
-        if self._solver_class == _otfm.OTFlowMatching and vf_kwargs is not None:
-            raise ValueError("For `solver='otfm'`, `vf_kwargs` must be `None`.")
-        if self._solver_class == _genot.GENOT:
-            if vf_kwargs is None:
-                vf_kwargs = {"genot_source_dims": [1024, 1024, 1024], "genot_source_dropout": 0.0}
-            else:
-                assert isinstance(vf_kwargs, dict)
-                assert "genot_source_dims" in vf_kwargs
-                assert "genot_source_dropout" in vf_kwargs
-        else:
-            vf_kwargs = {}
+        # Each velocity field owns which solver-specific `vf_kwargs` it accepts (validated/defaulted here).
+        vf_kwargs = self._vf_class._normalize_vf_kwargs(vf_kwargs)
         covariates_not_pooled = [] if pool_sample_covariates else self._dm.sample_covariates
         solver_kwargs = solver_kwargs or {}
         probability_path = probability_path or {"constant_noise": 0.0}
@@ -483,30 +473,16 @@ class CellFlow:
                 f"The key of `probability_path` must be `'constant_noise'` or `'bridge'` but found {probability_path}."
             )
 
-        if self._solver_class == _otfm.OTFlowMatching:
-            self._solver = self._solver_class(
-                vf=self.vf,
-                match_fn=match_fn,
-                probability_path=probability_path,
-                optimizer=optimizer,
-                conditions=self.train_data.condition_data,
-                rng=jax.random.PRNGKey(seed),
-                **solver_kwargs,
-            )
-        elif self._solver_class == _genot.GENOT:
-            self._solver = self._solver_class(
-                vf=self.vf,
-                data_match_fn=match_fn,
-                probability_path=probability_path,
-                source_dim=self._data_dim,
-                target_dim=self._data_dim,
-                optimizer=optimizer,
-                conditions=self.train_data.condition_data,
-                rng=jax.random.PRNGKey(seed),
-                **solver_kwargs,
-            )
-        else:
-            raise NotImplementedError(f"Solver must be an instance of OTFlowMatching or GENOT, got {type(self.solver)}")
+        # Each solver owns how it names its match function / whether it needs source-target dims.
+        self._solver = self._solver_class(
+            vf=self.vf,
+            probability_path=probability_path,
+            optimizer=optimizer,
+            conditions=self.train_data.condition_data,
+            rng=jax.random.PRNGKey(seed),
+            **self._solver_class._match_kwargs(match_fn=match_fn, data_dim=self._data_dim),
+            **solver_kwargs,
+        )
 
         self._trainer = CellFlowTrainer(solver=self.solver, predict_kwargs=self.validation_data["predict_kwargs"])  # type: ignore[arg-type]
 

--- a/src/cellflow/networks/_velocity_field.py
+++ b/src/cellflow/networks/_velocity_field.py
@@ -138,6 +138,18 @@ class ConditionalVelocityField(nn.Module):
     layer_norm_before_concatenation: bool = False
     linear_projection_before_concatenation: bool = False
 
+    @staticmethod
+    def _normalize_vf_kwargs(vf_kwargs: dict[str, Any] | None) -> dict[str, Any]:
+        """Validate/normalize the solver-specific ``vf_kwargs`` this velocity field is built with.
+
+        Called by :meth:`cellflow.model.CellFlow.prepare_model` so each velocity field owns which extra
+        constructor kwargs it accepts, keeping the model code free of per-solver branches. The plain
+        conditional field takes none.
+        """
+        if vf_kwargs is not None:
+            raise ValueError("For `solver='otfm'`, `vf_kwargs` must be `None`.")
+        return {}
+
     def setup(self):
         """Initialize the network."""
         if isinstance(self.conditioning_kwargs, dataclasses.Field):
@@ -507,6 +519,20 @@ class GENOTConditionalVelocityField(ConditionalVelocityField):
     genot_source_dropout: float = 0.0
     layer_norm_before_concatenation: bool = False
     linear_projection_before_concatenation: bool = False
+
+    @staticmethod
+    def _normalize_vf_kwargs(vf_kwargs: dict[str, Any] | None) -> dict[str, Any]:
+        """GENOT's velocity field needs source-processing kwargs; default them when not given.
+
+        See :meth:`ConditionalVelocityField._normalize_vf_kwargs`. ``GENOT`` requires
+        ``genot_source_dims`` and ``genot_source_dropout``.
+        """
+        if vf_kwargs is None:
+            return {"genot_source_dims": [1024, 1024, 1024], "genot_source_dropout": 0.0}
+        assert isinstance(vf_kwargs, dict)
+        assert "genot_source_dims" in vf_kwargs
+        assert "genot_source_dropout" in vf_kwargs
+        return vf_kwargs
 
     def setup(self):
         """Initialize the network."""

--- a/src/cellflow/solvers/__init__.py
+++ b/src/cellflow/solvers/__init__.py
@@ -1,4 +1,10 @@
+from cellflow.networks._velocity_field import ConditionalVelocityField, GENOTConditionalVelocityField
 from cellflow.solvers._genot import GENOT
 from cellflow.solvers._otfm import ClassifierFreeGuidance, Guidance, OTFlowMatching
+from cellflow.solvers._registry import SOLVER_REGISTRY, register_solver
 
-__all__ = ["GENOT", "OTFlowMatching", "ClassifierFreeGuidance", "Guidance"]
+# Built-in solvers, resolved by name in `CellFlow(solver=...)`.
+register_solver("otfm", OTFlowMatching, ConditionalVelocityField)
+register_solver("genot", GENOT, GENOTConditionalVelocityField)
+
+__all__ = ["GENOT", "OTFlowMatching", "ClassifierFreeGuidance", "Guidance", "SOLVER_REGISTRY", "register_solver"]

--- a/src/cellflow/solvers/_genot.py
+++ b/src/cellflow/solvers/_genot.py
@@ -57,6 +57,17 @@ class GENOT:
         Keyword arguments.
     """
 
+    @staticmethod
+    def _match_kwargs(*, match_fn: Callable, data_dim: int) -> dict[str, Any]:
+        """Solver-specific constructor kwargs derived from the model's match function and data dim.
+
+        Called by :meth:`cellflow.model.CellFlow.prepare_model` so each solver owns how it names its
+        matching function and whether it needs source/target dimensions, keeping the model code free of
+        per-solver branches. ``GENOT`` matches on ``data_match_fn`` and needs explicit
+        ``source_dim``/``target_dim``.
+        """
+        return {"data_match_fn": match_fn, "source_dim": data_dim, "target_dim": data_dim}
+
     def __init__(
         self,
         vf: nn.Module,

--- a/src/cellflow/solvers/_otfm.py
+++ b/src/cellflow/solvers/_otfm.py
@@ -130,6 +130,16 @@ class OTFlowMatching:
             Keyword arguments for :meth:`cellflow.networks.ConditionalVelocityField.create_train_state`.
     """
 
+    @staticmethod
+    def _match_kwargs(*, match_fn: Callable, data_dim: int) -> dict[str, Any]:
+        """Solver-specific constructor kwargs derived from the model's match function and data dim.
+
+        Called by :meth:`cellflow.model.CellFlow.prepare_model` so each solver owns how it names its
+        matching function and whether it needs source/target dimensions, keeping the model code free of
+        per-solver branches. ``OTFlowMatching`` matches on ``match_fn`` and takes no explicit dimensions.
+        """
+        return {"match_fn": match_fn}
+
     def __init__(
         self,
         vf: ConditionalVelocityField,

--- a/src/cellflow/solvers/_registry.py
+++ b/src/cellflow/solvers/_registry.py
@@ -1,0 +1,33 @@
+"""Name-based registry mapping a solver name to its ``(solver, velocity-field)`` classes.
+
+:class:`cellflow.model.CellFlow` resolves the solver and velocity-field classes for ``solver=<name>``
+from :data:`SOLVER_REGISTRY` instead of a hardcoded ``if/elif`` chain, so additional solvers can be
+made selectable with :func:`register_solver` without touching the model code.
+"""
+
+from __future__ import annotations
+
+__all__ = ["SOLVER_REGISTRY", "register_solver"]
+
+#: Maps a solver name (as passed to ``CellFlow(solver=...)``) to its ``(solver_class,
+#: velocity_field_class)`` pair. Populated for the built-ins in :mod:`cellflow.solvers`.
+SOLVER_REGISTRY: dict[str, tuple[type, type]] = {}
+
+
+def register_solver(name: str, solver_cls: type, vf_cls: type) -> None:
+    """Register a solver so it can be selected via ``CellFlow(solver=name)``.
+
+    Parameters
+    ----------
+    name
+        Name used to select the solver, e.g. ``"otfm"``. Re-registering an existing name overwrites it.
+    solver_cls
+        The solver class, e.g. :class:`cellflow.solvers.OTFlowMatching`.
+    vf_cls
+        The velocity-field class paired with ``solver_cls``.
+
+    Returns
+    -------
+    :obj:`None`. Adds ``name -> (solver_cls, vf_cls)`` to :data:`SOLVER_REGISTRY`.
+    """
+    SOLVER_REGISTRY[name] = (solver_cls, vf_cls)

--- a/tests/solver/test_registry.py
+++ b/tests/solver/test_registry.py
@@ -1,0 +1,99 @@
+import anndata as ad
+import numpy as np
+import pytest
+
+import cellflow
+from cellflow.networks import ConditionalVelocityField, GENOTConditionalVelocityField
+from cellflow.solvers import GENOT, SOLVER_REGISTRY, OTFlowMatching, register_solver
+
+
+@pytest.fixture
+def dummy_adata() -> ad.AnnData:
+    # `CellFlow.__init__` only stores `adata` and resolves the solver/VF classes from the registry,
+    # so a minimal AnnData is enough to exercise name-based resolution.
+    return ad.AnnData(X=np.zeros((3, 4), dtype=np.float32))
+
+
+class TestSolverRegistry:
+    def test_builtins_registered(self):
+        assert SOLVER_REGISTRY["otfm"] == (OTFlowMatching, ConditionalVelocityField)
+        assert SOLVER_REGISTRY["genot"] == (GENOT, GENOTConditionalVelocityField)
+
+    @pytest.mark.parametrize(
+        ("name", "solver_cls", "vf_cls"),
+        [
+            ("otfm", OTFlowMatching, ConditionalVelocityField),
+            ("genot", GENOT, GENOTConditionalVelocityField),
+        ],
+    )
+    def test_cellflow_resolves_from_registry(self, dummy_adata, name, solver_cls, vf_cls):
+        cf = cellflow.model.CellFlow(dummy_adata, solver=name)
+        assert cf._solver_class is solver_cls
+        assert cf._vf_class is vf_cls
+
+    def test_unknown_solver_raises_listing_names(self, dummy_adata):
+        with pytest.raises(ValueError, match=r"Unknown solver 'nope'") as excinfo:
+            cellflow.model.CellFlow(dummy_adata, solver="nope")
+        # The error lists the registered names so the user knows the valid options.
+        message = str(excinfo.value)
+        assert "otfm" in message
+        assert "genot" in message
+
+    def test_register_custom_solver_selectable(self, dummy_adata):
+        # A registered solver/VF pair implements the two integration hooks `prepare_model` reads:
+        # the solver's `_match_kwargs` and the VF's `_normalize_vf_kwargs`.
+        class DummySolver:
+            @staticmethod
+            def _match_kwargs(*, match_fn, data_dim):
+                return {"match_fn": match_fn}
+
+        class DummyVF:
+            @staticmethod
+            def _normalize_vf_kwargs(vf_kwargs):
+                return vf_kwargs or {}
+
+        assert "dummy" not in SOLVER_REGISTRY
+        register_solver("dummy", DummySolver, DummyVF)
+        try:
+            assert SOLVER_REGISTRY["dummy"] == (DummySolver, DummyVF)
+            cf = cellflow.model.CellFlow(dummy_adata, solver="dummy")
+            assert cf._solver_class is DummySolver
+            assert cf._vf_class is DummyVF
+        finally:
+            SOLVER_REGISTRY.pop("dummy", None)
+
+
+class TestSolverHooks:
+    """The per-solver/VF hooks `prepare_model` uses instead of hardcoded class branches."""
+
+    def test_otfm_match_kwargs(self):
+        def f(x, y):
+            return x
+
+        assert OTFlowMatching._match_kwargs(match_fn=f, data_dim=5) == {"match_fn": f}
+
+    def test_genot_match_kwargs(self):
+        def f(x, y):
+            return x
+
+        assert GENOT._match_kwargs(match_fn=f, data_dim=5) == {
+            "data_match_fn": f,
+            "source_dim": 5,
+            "target_dim": 5,
+        }
+
+    def test_otfm_vf_kwargs_must_be_none(self):
+        assert ConditionalVelocityField._normalize_vf_kwargs(None) == {}
+        with pytest.raises(ValueError, match=r"`vf_kwargs` must be `None`"):
+            ConditionalVelocityField._normalize_vf_kwargs({"genot_source_dims": (1, 1)})
+
+    def test_genot_vf_kwargs_defaults_and_validation(self):
+        # Defaulted when omitted ...
+        defaulted = GENOTConditionalVelocityField._normalize_vf_kwargs(None)
+        assert set(defaulted) == {"genot_source_dims", "genot_source_dropout"}
+        # ... passed through when the required keys are present ...
+        given = {"genot_source_dims": (2, 2), "genot_source_dropout": 0.1}
+        assert GENOTConditionalVelocityField._normalize_vf_kwargs(given) is given
+        # ... and rejected when a required key is missing.
+        with pytest.raises(AssertionError):
+            GENOTConditionalVelocityField._normalize_vf_kwargs({"genot_source_dropout": 0.1})

--- a/tests/solver/test_registry_regression.py
+++ b/tests/solver/test_registry_regression.py
@@ -1,0 +1,195 @@
+"""Regression coverage for the name-based solver/VF registry refactor.
+
+Pins that resolving solvers by name + the per-class hooks (`_match_kwargs`, `_normalize_vf_kwargs`)
+reproduce the behavior of the old hardcoded `if self._solver_class == ...` chain, end to end:
+class resolution, constructor-kwarg wiring, `vf_kwargs` validation, full train/predict for the
+built-ins, and a freshly registered custom solver going through the whole pipeline.
+"""
+
+import inspect
+
+import numpy as np
+import pytest
+
+import cellflow
+from cellflow.networks import ConditionalVelocityField, GENOTConditionalVelocityField
+from cellflow.solvers import GENOT, SOLVER_REGISTRY, OTFlowMatching, register_solver
+
+# Kwargs `prepare_model` always supplies to the solver constructor (the rest are solver-specific and
+# come from `_match_kwargs`). `optimizer`/`conditions`/`rng` are consumed via **kwargs at runtime.
+_COMMON_SOLVER_KWARGS = {"vf", "probability_path", "optimizer", "conditions", "rng"}
+
+
+def _prepare_data(cf) -> None:
+    cf.prepare_data(
+        sample_rep="X",
+        control_key="control",
+        perturbation_covariates={"drug": ["drug1"]},
+        perturbation_covariate_reps={"drug": "drug"},
+    )
+
+
+def _required_init_params(cls) -> set[str]:
+    """Names of `cls.__init__` parameters that have no default (excluding self/*args/**kwargs)."""
+    params = inspect.signature(cls.__init__).parameters
+    return {
+        name
+        for name, p in params.items()
+        if name != "self" and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD) and p.default is p.empty
+    }
+
+
+class TestStructuralRegression:
+    """Fast, no model building: guards the hook <-> constructor contract and registry integrity."""
+
+    @pytest.mark.parametrize("solver_cls", [OTFlowMatching, GENOT])
+    def test_match_kwargs_cover_required_ctor_params(self, solver_cls):
+        # Everything `prepare_model` would hand the constructor must include every required arg,
+        # so a future change to a ctor or to `_match_kwargs` that drops one is caught here.
+        passed = _COMMON_SOLVER_KWARGS | set(solver_cls._match_kwargs(match_fn=lambda a, b: a, data_dim=7))
+        missing = _required_init_params(solver_cls) - passed
+        assert not missing, f"prepare_model would omit required ctor args {missing} for {solver_cls.__name__}"
+
+    def test_match_kwargs_exact_shape(self):
+        f = lambda a, b: a
+        assert OTFlowMatching._match_kwargs(match_fn=f, data_dim=9) == {"match_fn": f}
+        assert GENOT._match_kwargs(match_fn=f, data_dim=9) == {
+            "data_match_fn": f,
+            "source_dim": 9,
+            "target_dim": 9,
+        }
+
+    def test_registry_mutation_isolated(self):
+        builtins = {"otfm": SOLVER_REGISTRY["otfm"], "genot": SOLVER_REGISTRY["genot"]}
+        name = "regression_tmp"
+        assert name not in SOLVER_REGISTRY
+        register_solver(name, OTFlowMatching, ConditionalVelocityField)
+        try:
+            assert SOLVER_REGISTRY[name] == (OTFlowMatching, ConditionalVelocityField)
+            register_solver(name, GENOT, GENOTConditionalVelocityField)  # re-registering overwrites
+            assert SOLVER_REGISTRY[name] == (GENOT, GENOTConditionalVelocityField)
+        finally:
+            SOLVER_REGISTRY.pop(name, None)
+        assert name not in SOLVER_REGISTRY
+        # Built-ins are untouched by registering/removing other names.
+        assert SOLVER_REGISTRY["otfm"] == builtins["otfm"]
+        assert SOLVER_REGISTRY["genot"] == builtins["genot"]
+
+
+@pytest.mark.slow
+class TestBuiltinPipelineRegression:
+    """End-to-end parity for the built-in solvers resolved through the registry (uses cf_trained)."""
+
+    def test_resolved_classes_and_instances(self, cf_trained):
+        cf, _ = cf_trained
+        name = "genot" if isinstance(cf.solver, GENOT) else "otfm"
+        solver_cls, vf_cls = SOLVER_REGISTRY[name]
+        assert cf._solver_class is solver_cls
+        assert cf._vf_class is vf_cls
+        assert isinstance(cf.solver, solver_cls)
+        assert isinstance(cf.vf, vf_cls)
+
+    def test_solver_and_vf_construction_kwargs(self, cf_trained):
+        cf, _ = cf_trained
+        if isinstance(cf.solver, GENOT):
+            # `data_match_fn` naming + explicit source/target dims flowed through `_match_kwargs`,
+            assert cf.solver.source_dim == cf._data_dim
+            assert hasattr(cf.solver, "data_match_fn")
+            assert hasattr(cf.solver, "latent_noise_fn")
+            # and the genot `vf_kwargs` were forwarded to the velocity field.
+            assert tuple(cf.vf.genot_source_dims) == (2, 2)
+        else:
+            assert hasattr(cf.solver, "match_fn")
+            assert not hasattr(cf.solver, "source_dim")
+            assert not hasattr(cf.vf, "genot_source_dims")
+
+    def test_predict_end_to_end(self, cf_trained):
+        cf, adata = cf_trained
+        assert cf.solver.is_trained
+        adata_pred = adata.copy()
+        adata_pred.obs["control"] = True
+        pred = cf.predict(
+            adata_pred,
+            sample_rep="X",
+            covariate_data=adata_pred.obs.iloc[:3],
+            max_steps=3,
+            throw=False,
+        )
+        assert isinstance(pred, dict)
+        out = next(iter(pred.values()))
+        assert out.shape[1] == cf._data_dim
+        assert np.all(np.isfinite(np.asarray(out)))
+
+
+@pytest.mark.slow
+class TestVfKwargsEndToEnd:
+    """The `vf_kwargs` validation now owned by the VF classes, exercised through `prepare_model`."""
+
+    def test_otfm_rejects_vf_kwargs(self, adata_perturbation):
+        cf = cellflow.model.CellFlow(adata_perturbation, solver="otfm")
+        _prepare_data(cf)
+        with pytest.raises(ValueError, match=r"`vf_kwargs` must be `None`"):
+            cf.prepare_model(
+                condition_embedding_dim=2,
+                hidden_dims=(2, 2),
+                decoder_dims=(2, 2),
+                vf_kwargs={"genot_source_dims": (2, 2), "genot_source_dropout": 0.1},
+            )
+
+    def test_genot_missing_required_vf_kwarg_raises(self, adata_perturbation):
+        cf = cellflow.model.CellFlow(adata_perturbation, solver="genot")
+        _prepare_data(cf)
+        with pytest.raises(AssertionError):
+            cf.prepare_model(
+                condition_embedding_dim=2,
+                hidden_dims=(2, 2),
+                decoder_dims=(2, 2),
+                vf_kwargs={"genot_source_dropout": 0.1},  # missing `genot_source_dims`
+            )
+
+
+@pytest.fixture
+def registered_custom_solver():
+    # A working custom solver = thin OTFlowMatching subclass; inherits `_match_kwargs`. Registered
+    # under a fresh name and removed afterwards so the global registry is not polluted.
+    class RegistryRegressionSolver(OTFlowMatching):
+        pass
+
+    name = "regression_custom"
+    assert name not in SOLVER_REGISTRY
+    register_solver(name, RegistryRegressionSolver, ConditionalVelocityField)
+    try:
+        yield name, RegistryRegressionSolver
+    finally:
+        SOLVER_REGISTRY.pop(name, None)
+
+
+@pytest.mark.slow
+class TestCustomSolverEndToEnd:
+    """A newly registered solver is not just selectable but trains and predicts through the pipeline."""
+
+    def test_registered_custom_solver_full_pipeline(self, adata_perturbation, registered_custom_solver):
+        name, solver_cls = registered_custom_solver
+
+        cf = cellflow.model.CellFlow(adata_perturbation, solver=name)
+        assert cf._solver_class is solver_cls
+        _prepare_data(cf)
+        cf.prepare_model(condition_embedding_dim=2, hidden_dims=(2, 2), decoder_dims=(2, 2))
+        assert isinstance(cf.solver, solver_cls)
+
+        cf.train(num_iterations=3)
+        assert cf.solver.is_trained
+
+        adata_pred = adata_perturbation.copy()
+        adata_pred.obs["control"] = True
+        pred = cf.predict(
+            adata_pred,
+            sample_rep="X",
+            covariate_data=adata_pred.obs.iloc[:3],
+            max_steps=3,
+            throw=False,
+        )
+        assert isinstance(pred, dict)
+        out = next(iter(pred.values()))
+        assert out.shape[1] == cf._data_dim
+        assert np.all(np.isfinite(np.asarray(out)))


### PR DESCRIPTION
Resolve the solver and velocity-field classes for CellFlow(solver=...) from a SOLVER_REGISTRY instead of a hardcoded if/elif chain, so new solvers can be made selectable via register_solver without touching the model code.
