### PR TITLE
solvers: fix GENOT flow-matching target (target − latent, not target − source)

### DIFF
--- a/src/cellflow/solvers/_genot.py
+++ b/src/cellflow/solvers/_genot.py
@@ -132,12 +132,7 @@ class GENOT:
                     encoder_noise=encoder_noise,
                     rngs={"dropout": rng_dropout, "condition_encoder": rng_encoder},
                 )
-                # The flow-matching target is the velocity of the path the ODE integrates: the path
-                # goes from the latent (t=0, where `predict` starts) to the target (t=1), so the target
-                # is `target - latent`. The `source` enters only as the velocity field's condition
-                # (above). Using `source` here regresses onto the wrong vector field and biases every
-                # generated sample by `latent - source`. Matches GENOT (Klein et al., 2023): the loss
-                # is `||v_t(phi_t(noise, target) | source) - (target - noise)||^2`.
+                # GENOT target is the latent->target path velocity (target - latent); source only conditions v.
                 u_t = self.probability_path.compute_ut(t, x_t, latent, target)
                 flow_matching_loss = jnp.mean((v_t - u_t) ** 2)
                 condition_mean_regularization = 0.5 * jnp.mean(mean_cond**2)

--- a/src/cellflow/solvers/_genot.py
+++ b/src/cellflow/solvers/_genot.py
@@ -132,7 +132,13 @@ class GENOT:
                     encoder_noise=encoder_noise,
                     rngs={"dropout": rng_dropout, "condition_encoder": rng_encoder},
                 )
-                u_t = self.probability_path.compute_ut(t, x_t, source, target)
+                # The flow-matching target is the velocity of the path the ODE integrates: the path
+                # goes from the latent (t=0, where `predict` starts) to the target (t=1), so the target
+                # is `target - latent`. The `source` enters only as the velocity field's condition
+                # (above). Using `source` here regresses onto the wrong vector field and biases every
+                # generated sample by `latent - source`. Matches GENOT (Klein et al., 2023): the loss
+                # is `||v_t(phi_t(noise, target) | source) - (target - noise)||^2`.
+                u_t = self.probability_path.compute_ut(t, x_t, latent, target)
                 flow_matching_loss = jnp.mean((v_t - u_t) ** 2)
                 condition_mean_regularization = 0.5 * jnp.mean(mean_cond**2)
                 condition_var_regularization = -0.5 * jnp.mean(1 + logvar_cond - jnp.exp(logvar_cond))

--- a/tests/solver/test_genot_flow_target.py
+++ b/tests/solver/test_genot_flow_target.py
@@ -1,0 +1,78 @@
+"""Regression test for the GENOT flow-matching regression target.
+
+GENOT (Klein et al., 2023) learns a flow from a latent (noise) sample to the target,
+conditioned on the source. The flow-matching loss regresses the velocity field onto
+the velocity of that path, ``target - latent`` -- see the author's implementation
+(https://github.com/MUCDK/genot, ``genot/models/model.py``)::
+
+    phi_t(x_0, x_1, t) = (1 - t) * x_0 + t * x_1
+    u_t(x_0, x_1)      = x_1 - x_0
+    d_psi = u_t(batch["noise"], batch["target"])   # target - noise
+    loss  = mean(l2_loss(v_t(phi_t(noise, target) | source), d_psi))
+
+i.e. both the interpolation and ``u_t`` use ``(noise/latent, target)``; the source is
+only the velocity field's condition. Regressing onto ``target - source`` instead is a
+silent bug: it biases every generated sample by ``latent - source`` (no crash, since
+source and latent share the target dimensionality).
+
+This test traces the actual values passed to ``compute_xt``/``compute_ut`` during a
+real training step and asserts ``compute_ut`` receives the latent, not the source.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+
+import cellflow
+from cellflow._compat import ConstantNoiseFlow
+from cellflow.solvers import _genot
+from cellflow.utils import match_linear
+
+
+def test_genot_flow_matching_target_uses_latent_not_source():
+    vf = cellflow.networks.GENOTConditionalVelocityField(
+        output_dim=5,
+        max_combination_length=2,
+        condition_embedding_dim=12,
+        hidden_dims=(16, 16),
+        decoder_dims=(16, 16),
+        genot_source_dims=(16, 16),
+    )
+    solver = _genot.GENOT(
+        vf=vf,
+        data_match_fn=match_linear,
+        probability_path=ConstantNoiseFlow(0.0),
+        optimizer=optax.adam(1e-3),
+        source_dim=5,
+        target_dim=5,
+        conditions={"pert1": np.random.rand(2, 1, 3)},
+        rng=jax.random.PRNGKey(0),
+    )
+
+    # Record the x0 argument each primitive receives. Source cells are ~+100 and the
+    # latent is ~N(0, 1), so the x0 that reaches compute_ut is unambiguous by scale.
+    rec: dict[str, np.ndarray] = {}
+    flow = solver.probability_path
+    orig_xt, orig_ut = flow.compute_xt, flow.compute_ut
+    flow.compute_xt = lambda rng, t, x0, x1: (rec.__setitem__("xt_x0", x0), orig_xt(rng, t, x0, x1))[1]
+    flow.compute_ut = lambda t, x, x0, x1: (rec.__setitem__("ut_x0", x0), orig_ut(t, x, x0, x1))[1]
+
+    batch = {
+        "src_cell_data": jnp.ones((10, 5)) * 100.0,   # source cells ~ +100
+        "tgt_cell_data": jnp.ones((10, 5)) * -100.0,  # target ~ -100
+        "condition": {"pert1": jnp.ones((1, 2, 3))},
+    }
+
+    with jax.disable_jit():
+        solver.step_fn(jax.random.PRNGKey(1), batch)
+
+    xt_x0 = np.asarray(rec["xt_x0"])  # the latent the ODE starts from
+    ut_x0 = np.asarray(rec["ut_x0"])  # the regression-target path start
+
+    # compute_ut must use the same path start as compute_xt (the latent), matching the
+    # author's `u_t(batch["noise"], batch["target"])`. On the bug it is the source (~+100).
+    assert np.allclose(ut_x0, xt_x0), (
+        f"compute_ut regresses onto the wrong path start: got mean {ut_x0.mean():+.1f} "
+        f"(source) but expected the latent {xt_x0.mean():+.1f}."
+    )

--- a/tests/solver/test_genot_flow_target.py
+++ b/tests/solver/test_genot_flow_target.py
@@ -59,7 +59,7 @@ def test_genot_flow_matching_target_uses_latent_not_source():
     flow.compute_ut = lambda t, x, x0, x1: (rec.__setitem__("ut_x0", x0), orig_ut(t, x, x0, x1))[1]
 
     batch = {
-        "src_cell_data": jnp.ones((10, 5)) * 100.0,   # source cells ~ +100
+        "src_cell_data": jnp.ones((10, 5)) * 100.0,  # source cells ~ +100
         "tgt_cell_data": jnp.ones((10, 5)) * -100.0,  # target ~ -100
         "condition": {"pert1": jnp.ones((1, 2, 3))},
     }


### PR DESCRIPTION
## Summary

GENOT's flow-matching loss regresses the velocity field onto the **wrong vector field**: it uses `target − source` where it should use `target − latent`. This silently biases every GENOT prediction and has been present since the solver was introduced.

## The bug

`src/cellflow/solvers/_genot.py`, training loss:

```python
x_t = self.probability_path.compute_xt(rng_flow, t, latent, target)   # path: latent → target
...
u_t = self.probability_path.compute_ut(t, x_t, source, target)        # = target − source  ✗
```

GENOT learns a flow from a **latent** (noise) sample to the target, **conditioned** on the source. The regression target must be the velocity of that path, `target − latent`. Both the path `x_t` and inference (`predict` integrates the ODE from `y0 = latent`) use the latent, so training on `target − source` regresses onto an inconsistent field. A perfectly-trained model then lands at `latent + (target − source)` — off by `latent − source` on every sample.

It never raises: `source` and `latent` share the target dimensionality, so it is a **silent quality regression**, not a crash.

## Fix

```python
u_t = self.probability_path.compute_ut(t, x_t, latent, target)        # = target − latent  ✓
```

One line. `source` still enters as the velocity field's condition (unchanged). **OTFM is unaffected** — its flow starts at the source, so `target − source` is correct there.

## Verification against the primary sources

- **Author's reference implementation** ([MUCDK/genot](https://github.com/MUCDK/genot), `genot/models/model.py`):
  ```python
  d_psi = u_t(batch["noise"], batch["target"])          # target − noise
  loss  = mean(l2_loss(v_t(phi_t(noise, target) | source), d_psi))
  ```
  Both `phi_t` and `u_t` use `(noise, target)`; source is the condition only.
- **GENOT paper** (Klein et al., 2023): loss is `‖v_t([Z, Y]_t | X) − (Y − Z)‖²` with `Z` the noise, `Y` the target, `X` the source condition ⇒ target − noise.

## Test

Adds `tests/solver/test_genot_flow_target.py`, which traces the actual array reaching `compute_ut` during a real training step and asserts it is the latent, not the source. It **fails on the old code** (`compute_ut` x₀ = source) and **passes on the fix** (x₀ = latent).

## Impact

Existing GENOT checkpoints trained before this fix were trained on the biased objective; retraining is recommended to recover quality. No API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)